### PR TITLE
fix typo + clarify needed change

### DIFF
--- a/content/post/rust-error-handling.md
+++ b/content/post/rust-error-handling.md
@@ -1549,12 +1549,20 @@ enum CliError {
 }
 {{< /high >}}
 
-And add a new `From` impl:
+To reflect this change we need to update the previous
+`impl From<num::ParseIntError> for CliError` and add the new
+`impl From<num::ParseFloatError> for CliError`:
 
 {{< high "rust" >}}
+impl From<num::ParseIntError> for CliError {
+    fn from(err: num::ParseIntError) -> CliError {
+        CliError::ParseInt(err)
+    }
+}
+
 impl From<num::ParseFloatError> for CliError {
     fn from(err: num::ParseFloatError) -> CliError {
-        CliError::Parse(err)
+        CliError::ParseFloat(err)
     }
 }
 {{< /high >}}


### PR DESCRIPTION
Main reason: updated `CliError` made the code invalid.

Original code:
```
{{< high "rust" >}}
enum CliError {
    Io(io::Error),
    ParseInt(num::ParseIntError),
    ParseFloat(num::ParseFloatError),
}
{{< /high >}}

And add a new `From` impl:

{{< high "rust" >}}
impl From<num::ParseFloatError> for CliError {
    fn from(err: num::ParseFloatError) -> CliError {
        CliError::Parse(err)
    }
}
{{< /high >}}
```

```
        CliError::Parse(err)
```

Doesn't exist since the definition of `CliError` changed; this also invalidate the previous definition of `impl From<num::ParseIntError> for CliError`.  Therefore I changed the text to reflect that it's an update and provided the code change needed to reflect that.

That is
* update previous `impl From<num::ParseIntError> for CliError`
* add `impl From<num::ParseFloatError> for CliError`