### PR TITLE
Use native system font for body text

### DIFF
--- a/static/css/basscss.css
+++ b/static/css/basscss.css
@@ -32,7 +32,7 @@ article, aside, details, figcaption, figure, footer, header, main, nav, section,
 }
 
 body {
-  font-family: 'Helvetica Neue', Helvetica, sans-serif;
+  font-family: system-ui, 'Helvetica Neue', Helvetica, sans-serif;
   line-height: 1.5rem;
   font-weight: 400;
 }


### PR DESCRIPTION
I realise that this is highly subjective, but I personally like it when websites use the system’s native system font. I believe that GitHub, Twitter and Bootstrap do this, so I guess you can look to those to form an opinion of what it looks like.

Side note: Currently the blog uses Helvetica Neue when available, which is in the same typeface category as {macOS,Android}’s system fonts, making the whole thing feel slightly ‘off’ (for me at least). I think this might be because people tend(?) to become so familiar with their system’s font (even unconsciously), so seeing something that is quite similar to what you’re used to, but not _exactly_ the same creates a strange effect.

Thanks for the fantastic articles, especially the recent one about your experiences in FOSS.