### PR TITLE
add rss link in header, exclude meta posts

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html>
+
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -11,6 +12,10 @@
   <meta name="author" content="">
   <meta name="keywords" content="">
   <link rel="canonical" href="{{ .Permalink }}">
+
+  {{ with .OutputFormats.Get "rss" -}}
+  {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
+  {{ end -}}
 
   <!-- Custom CSS -->
   <link rel="stylesheet" type="text/css" href="{{ .Site.BaseURL }}css/basscss.css">

--- a/layouts/rss.xml
+++ b/layouts/rss.xml
@@ -7,7 +7,7 @@
     {{ with .Site.Author.name }}<author>{{.}}</author>{{end}}
     {{ with .Site.Copyright }}<copyright>{{.}}</copyright>{{end}}
     <updated>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 MST" }}</updated>
-    {{ range first 15 .Data.Pages }}
+    {{ range first 15 (where .Data.Pages "Section" "post") }}
     <item>
       <title>{{ .Title }}</title>
       <link>{{ .Permalink }}</link>


### PR DESCRIPTION
hi, when visiting your rss feed at https://blog.burntsushi.net/index.xml I only see two meta items. When I ran your blog locally (using `make server-local` with hugo `v0.57.2/extended linux/amd64 BuildDate: 2019-08-18T05:29:32Z`) the output included all posts though. Not sure what the issue is there..

So I made two changes:
- link to the rss feed in the header such that scrapers can easily detect it
- not show "meta" posts in the rss feed (specifially, the "about me"). the "about me" also contains an invalid date from the year 0001 ;-)