### PR TITLE
Actually double arg

### DIFF
--- a/code/rust-error-handling/src/bin/error-double-string.rs
+++ b/code/rust-error-handling/src/bin/error-double-string.rs
@@ -7,6 +7,7 @@ fn double_arg(mut argv: env::Args) -> Result<i32, String> {
     argv.nth(1)
         .ok_or("Please give at least one argument".to_owned())
         .and_then(|arg| arg.parse::<i32>().map_err(|err| err.to_string()))
+        .map(|i| i * 2)
 }
 
 fn main() {

--- a/content/post/rust-error-handling.md
+++ b/content/post/rust-error-handling.md
@@ -767,6 +767,7 @@ fn double_arg(mut argv: env::Args) -> Result<i32, String> {
     argv.nth(1)
         .ok_or("Please give at least one argument".to_owned())
         .and_then(|arg| arg.parse::<i32>().map_err(|err| err.to_string()))
+        .map(|i| i * 2)
 }
 
 fn main() {


### PR DESCRIPTION
Changed the code to actually double the argument.

Tested the change by running: `cargo run --bin error-double-string 33`