### PR TITLE
Fix broken link to FST Node struct

### DIFF
--- a/content/post/transducers.md
+++ b/content/post/transducers.md
@@ -1780,7 +1780,7 @@ fn contains_key(fst: &Fst, key: &[u8]) -> bool {
 
 And that's pretty much all there is to it. The
 [`Node` type has a few more useful
-documented methods](https://burntsushi.net/rustdoc/fst/raw/struct.Node.html)
+documented methods](https://burntsushi.net/rustdoc/fst/latest/fst/raw/struct.Node.html)
 that you may want to peruse.
 
 ## The FST command line tool


### PR DESCRIPTION
The current link points to a page which says "The requested version does not exist / no such version for this crate". Updated it to point to the latest version of the `fst` crate.